### PR TITLE
Update to work with bittorrent-protocol@1.5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = function () {
     self.reset()
   }
 
+  ut_pex.prototype.name = 'ut_pex'
+
   /**
    * Start sending regular PEX updates to remote peer.
    */


### PR DESCRIPTION
We can’t rely on Function.name to determine the name of the extension,
so we need to set it on the prototype.

See: https://github.com/feross/bittorrent-protocol/commit/0b0942492adcd0ec22bf4fa05259faf4d0191a28

Quick merge and release would be appreciated!
